### PR TITLE
added arm64 linux kernel image MIME type

### DIFF
--- a/mime/linux
+++ b/mime/linux
@@ -208,6 +208,8 @@
 !:mime  linux/kernel
 36	belong	0x016f2818	Linux kernel ARM boot executable zImage (big-endian)
 !:mime  linux/kernel
+56	lelong  0x644d5241  Linux kernel ARM64 boot executable Image
+!:mime  linux/kernel
 
 ############################################################################
 # Linux 8086 executable


### PR DESCRIPTION
added the missing arm64 image type (without it, those kernel images are not detected as kernel image in FACT and are not unpacked/analyzed properly)