### PR TITLE
Source release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,25 @@ on:
 
 jobs:
   release:
-    # We use Ubuntu 20.04 to have an older version of the file tool.
-    # If we used a newer Ubuntu it it would complain about incompatible magic
-    # file format on older Ubuntu versions.
-    runs-on: ubuntu-20.04
+    # Compiled magic files are incompatible with older and (for whatever
+    # reason) also newer versions of `file`.
+    # Therefore, we only release the concatenated, compressed source file.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Make
-        run: sudo apt-get install make
+        run: sudo apt-get install make xz-utils
 
       - name: Build
-        run: make all
+        run: |
+          make firmware
+          xz -f -7 -k firmware
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: firmware.mgc
+          files: firmware.xz

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-fact
-fact.mgc
+firmware
+firmware.mgc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: firmware.mgc
+all: mgc firmware
+
+mgc: firmware.mgc
 
 firmware.mgc: firmware
 	file -C -m firmware
@@ -9,3 +11,4 @@ firmware:
 clean:
 	rm -f firmware
 	rm -f firmware.mgc
+	rm -f firmware.xz

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ and deletes all the code and just keeps the magic definitions (despite
 Thus, this repository is also licensed under the GPLv3.
 
 ## Installation
-Run `make` to create a compiled mime database `firmware.mgc`.
-Alternatively, you can head over to the [releases][releases] and download the
-compiled database from there.
+Run `make` to create two files: A compiled mime database `firmware.mgc` and a
+non-compiled mime database `firmware`.
+Alternatively, you can head over to the [releases][releases] to download the
+non-compiled database from there.
+The downloaded file needs to be uncompressed before it can be used with `file`.
+Note that the compiled database is only of use if your version of `file` is the
+same as the version that the database was compiled.
+For this reason, you can only download the non-compiled version.
 
-For example, you can put this in the directory shown by `file -v` to make use of
-it when using the standard unix `file` tool.
+Use these files by setting the `MAGIC` environment variable,
+for more information see `magic(5)`.
 
 
 [fact_helper_file]: https://github.com/fkie-cad/fact_helper_file/commit/17065a2d81bfdebd3425427eefaca9857087c763

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# A maigc database for firmware analysis
+# A magic database for firmware analysis
 This repository contains magic definitions for filetypes commonly found in firmwares.
 This is a fork of [fact\_helper\_file][fact_helper_file]
 and deletes all the code and just keeps the magic definitions (despite
 [custom_mime_internal][custom_mime_internal]).
-Thus this repository is also licensed under the GPLv3.
+Thus, this repository is also licensed under the GPLv3.
 
 ## Installation
 Run `make` to create a compiled mime database `firmware.mgc`.
-Alternatively you can head over to the [releases][releases] and download the
+Alternatively, you can head over to the [releases][releases] and download the
 compiled database from there.
 
-For example you can put this in the directory shown by `file -v` to make use of
-it when using the standart unix `file` tool.
+For example, you can put this in the directory shown by `file -v` to make use of
+it when using the standard unix `file` tool.
 
 
 [fact_helper_file]: https://github.com/fkie-cad/fact_helper_file/commit/17065a2d81bfdebd3425427eefaca9857087c763
 [custom_mime_internal]: https://github.com/fkie-cad/fact_helper_file/blob/17065a2d81bfdebd3425427eefaca9857087c763/fact_helper_file/mime/custom_mime_internal
-[releases]: https://github.com/maringuu/firmware-magic-database/releases
+[releases]: https://github.com/fkie-cad/firmware-magic-database/releases


### PR DESCRIPTION
- fixes a link and some typos and missing commas in the `README.md`
- adds a "xz" make target (which is the compressed source file)
- replaces the .mgc file with the .xz file in the release
- updated the .gitignore