### PR TITLE
bootloader: add Flattened Device Tree support

### DIFF
--- a/mime/bootloader
+++ b/mime/bootloader
@@ -77,6 +77,33 @@
 >8  byte    !0x2E       {invalid}
 >0  string  x           "%s"
 
+# Flattened Device Tree
+0	belong	0xd00dfeed	Flattened Device Tree header,
+!:mime firmware/fdt
+>4	belong	x		total size: %d,
+>8	belong	x		structure offset: %d,
+>12	belong	x		strings offset: %d,
+>16	belong	x		memory reserve map offset: %d,
+>20	belong	x		version: %d,
+
+>20	belong	1
+>>24	belong	x		last compatible version: %d
+
+>20	belong 	2
+>>24	belong	x		last compatible version: %d,
+>>28	belong	x		boot cpu id: %d
+
+>20	belong	3
+>>24	belong	x		last compatible version: %d,
+>>28	belong	x		boot cpu id: %d,
+>>32	belong	x		strings block size: %d
+
+>20	belong	17
+>>24	belong	x		last compatible version: %d,
+>>28	belong	x		boot cpu id: %d,
+>>32	belong	x		strings block size: %d,
+>>36	belong	x		structure block size: %d
+
 # CFE bootloader
 # original code from binwalk
 0	string	CFE1	    CFE boot loader


### PR DESCRIPTION
Derived from https://github.com/u-boot/u-boot/blob/master/scripts/dtc/libfdt/fdt.h#L12-L29

Example:
```
$ file -m firmware ~/1a654eb0-56bc-4df9-a1f7-8627e1f4f9ce/linux_a 
/home/alamarche/1a654eb0-56bc-4df9-a1f7-8627e1f4f9ce/linux_a: Flattened Device Tree header, total size: 14882016, structure offset: 56, strings offset: 14881900, memory reserve map offset: 40, version: 17, last compatible version: 16, boot cpu id: 0, strings block size: 116, structure block size: 14881844
```