### PR TITLE
linux: fix device tree for large images

### DIFF
--- a/mime/linux
+++ b/mime/linux
@@ -420,22 +420,21 @@
 >>0x1046	ubeshort	x	\b%04x
 
 # Linux device tree:
-# File format description can be found in the Linux kernel sources at 
+# File format description can be found in the Linux kernel sources at
 # Documentation/devicetree/booting-without-of.txt
 # From Christoph Biedl
 0		belong		0xd00dfeed
-# structure and strings must be within blob
+# structure must be within blob, strings are omitted to handle devicetrees > 1M
 >&(8.L)		byte		x
->>&(12.L)	byte		x
->>>20		belong		>1	Device Tree Blob version %d
+>>20		belong		>1	Device Tree Blob version %d
 !:mime  linux/device-tree
->>>>4		belong		x	\b, size=%d
->>>>20		belong		>1
->>>>>28		belong		x	\b, boot CPU=%d
->>>>20		belong		>2
->>>>>32		belong		x	\b, string block size=%d
->>>>20		belong		>16
->>>>>36		belong		x	\b, DT structure block size=%d
+>>>4		belong		x	\b, size=%d
+>>>20		belong		>1
+>>>>28		belong		x	\b, boot CPU=%d
+>>>20		belong		>2
+>>>>32		belong		x	\b, string block size=%d
+>>>20		belong		>16
+>>>>36		belong		x	\b, DT structure block size=%d
 
 # glibc locale archive as defined in glibc locale/locarchive.h
 0		lelong		0xde020109	locale archive


### PR DESCRIPTION
Enables detecting FDT larger than 1M, in turn supports FIT images containing kernels, DTs and rootfs.

Taken from https://github.com/file/file/blob/master/magic/Magdir/linux#L745-L759