### PR TITLE
firmware: support broadcom SAO images

### DIFF
--- a/mime/firmware_containers
+++ b/mime/firmware_containers
@@ -754,3 +754,27 @@
 >8      ulelong x                   crc32: 0x%X,
 >16     string x                    model: %s,
 >24     string x                    region: %s
+
+# Broadcom SAO image
+0	string 		SOBJ		Broadcom SAO image
+!:mime	firmware/broadcom-sao
+>4	ubelong		x		(header CRC: 0x%08x,
+>8	string		x		type: %.4s,
+>8	string		x		{name:%.4s.sao}
+>12	ushort		x		version: 0x%04x,
+>14	ushort		x		flags: 0x%x,
+>16	ubelong+64	x		size: %d,
+>16	ubelong+64	x		{size:%d}
+>25	ubyte		x		code type: 0x%02x,
+>26	ubyte&0x7f	x		sign type: 0x%02x
+>26	ubyte&0x80	!0		(encrypted)
+>52	ubelong		x		, data CRC: 0x%08x)
+
+# Broadcom SAO encryption header
+4	string		ENCK		Broadcom SAO encryption header
+!:mime	firmware/broadcom-sao-encrypted
+>0	ulong		x		(header CRC: 0x%08x,
+>8	ubelong+0x120	x		size: %d,
+>8	ubelong+0x120	x		{size:%d}
+>12	ubelong		x		data CRC: 0x%08x,
+>16	string		x		key id: %.4s)


### PR DESCRIPTION
Add support for detecting Broadcom SAO images, commonly found in DOCSIS cable modems.

Source: https://github.com/jclehner/bcm2-utils/blob/master/misc/binwalk_sobj.txt