### PR TITLE
feat: add maxlinear puma 7 firmware image

### DIFF
--- a/mime/firmware_containers
+++ b/mime/firmware_containers
@@ -952,3 +952,23 @@
 
 0  ubelong  0x62676e00  Buffalo Inc. firmware image
 !:mime firmware/buffalo
+
+# Intel (MaxLinear) UImage v2
+0       search/0x1000   VER2Intel_Unified_Image\x00                             Intel (MaxLinear) UImage v2,
+!:mime  firmware/maxlinear-uimage-v2
+>&12    ubelong         x                                                       size: %d
+
+# Intel (MaxLinear) UImage v2 Alternative
+0       search/0x1000   VER2Puma7_UImage\x00\x00\x00\x00\x00\x00\x00\x00        Intel (MaxLinear) UImage v2,
+!:mime  firmware/maxlinear-uimage-v2
+>&12    ubelong         x                                                       size: %d
+
+# Intel (MaxLinear) UImage v3
+0       search/0x1000   VER3Intel_Unified_Image\x00                             Intel (MaxLinear) UImage v3,
+!:mime  firmware/maxlinear-uimage-v3
+>&12    ubelong         x                                                       size: %d
+
+# Intel (MaxLinear) UImage v3 Alternative
+0       search/0x1000   VER3Puma7_UImage\x00\x00\x00\x00\x00\x00\x00\x00        Intel (MaxLinear) UImage v3,
+!:mime  firmware/maxlinear-uimage-v3
+>&12    ubelong         x                                                       size: %d


### PR DESCRIPTION
Puma 7 is a SoC used by DOCSIS cable modems. This is a really crude addition to detect Puma 7 firmware update files. The first 1000-2000 bytes are a CVC that varies in length, hence the need to use `search`.