### PR TITLE
feat: add MaxLinear Puma 8 vendor image magic

### DIFF
--- a/mime/firmware_containers
+++ b/mime/firmware_containers
@@ -980,3 +980,14 @@
 # secure version number
 >>>&0   ubelong         x
 >>>&4   pstring/L       x                                     model name: %s
+
+# Puma 8 Vendor Image
+0		search/4096	\x1c\x00\x00\x2b
+>0		byte		0x30
+>>1		byte		0x82
+>>>4		search/512	CableLabs\ CVC\ Certification\ Authority	(CableLabs Certificate Authority)
+>>>>0		search/4096	\x1c\x00\x00\x2b				Puma 8 Vendor Image
+!:mime		firmware/puma-8-vendor-image
+>>>>>&0		beshort		x						header len: %d,
+>>>>>&4		byte		x						vendor len: %d,
+>>>>>&5		regex		[[:alnum:][:blank:][:punct:]]+			vendor: %s


### PR DESCRIPTION
MaxLinear seems to have a new firmware image structure for Docsis 4.0 chips, specifically for vendors. The general structure is:

- PCKS7 certificate (DER ASN.1)
- Vendor header (TLV), consisting of the header size, the vendor, a crc of the firmware update and a few currently unknown bytes.
- A U-Boot image for the x64 system, as well as another (useless?) one for the vendor header.

A typical vendor header looks like the following:

1C 00 00 2B 00 22 01 00 18 48 69 74 72 6F 6E 20 54 65 63 68 6E 6F 6C 6F 67 69 65 73 20 49 6E 63 2E 02 00 04 3F 20 12 40 04 84 04 CF 58 3D

The 3rd byte (0x2b) is TLV43, indicating the header is from a vendor (e.g. Hitron, Vantiva, Commscope, etc.). The TLV follows a u8 type, u16 length and a value, which in the example is length 0x22. It seems reasonable to assume that there are nested TLVs, e.g. 0x01 0x00 0x18 indicates type 1, length 0x0018, and value Hitron Technologies Inc, followed by type 2, length 0x0004 and value 0x043f3012 (length of the actual firmware blob). I have not figured out the following 2 bytes, but the remaining 4 are a little-endian crc32 of the actual firmware blob.