### PR TITLE
feat: added draytek-rtos mime type

### DIFF
--- a/mime/firmware_containers
+++ b/mime/firmware_containers
@@ -736,6 +736,10 @@
 >-49    string  DrayTekImageMD5
 >-33    string  x                  MD5 (footer): %s
 
+# Draytek RTOS Firmware
+9       string  DkmfaaryTedecz  Draytek RTOS Firmware Container
+!:mime firmware/draytek-rtos
+
 # Instar BNEG container type
 0       string  \x42\x4e\x45\x47    Instar BNEG Firmware Container
 !:mime	firmware/bneg


### PR DESCRIPTION
The magic was guessed by comparing images that [draytek-arsenal](https://github.com/infobyte/draytek-arsenal) was able to extract.
Although there were neither false positives nor false negatives within the dataset of Draytek firmware update images I own, it would be nice to test this MIME type on a bigger dataset for possible false positives.

This is a duplicate of https://github.com/fkie-cad/fact_helper_file/pull/38